### PR TITLE
Rate-limit the output of the PHP Server messages

### DIFF
--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -18,6 +18,38 @@ const sanitize      = require('sanitize-filename');
 
 const CancellablePromise = require('./CancellablePromise');
 
+const messageWatcherMap = new Map();
+
+const rateLimit = message => {
+    const print = () => console.log(`The PHP Server has something to say: ${message}`);
+    if (messageWatcherMap.has(message)) {
+        const info = messageWatcherMap.get(message);
+        info.t1 = Date.now();
+        const triesPerSecond = info.tries * (60 * 1000 * 1000) / (info.t1 - info.t0 + 1);
+        info.counter = info.counter + triesPerSecond;
+
+        const news = {
+            target : 10 * 1000 * 1000 / 60,
+            tries: info.tries + 1,
+            triesPerSecond,
+            counter: info.counter
+        };
+
+        Object.assign(info, news);
+        if (info.counter >= info.target) {
+            print();
+            info.counter = 0;
+        }
+    } else {
+        messageWatcherMap.set(message, {
+            tries: 1,
+            t0: Date.now(),
+            counter: 0,
+        });
+        print();
+    }
+};
+
 module.exports =
 
 //#*
@@ -145,18 +177,13 @@ module.exports =
                 // }
             };
 
+
             const process = this.phpInvoker.invoke(parameters, additionalDockerRunParameters, options);
 
             return new Promise((resolve, reject) => {
                 process.stdout.on('data', data => {
                     const message = data.toString();
-
-                    console.debug('The PHP server has something to say:', message);
-
-                    if (message.indexOf('Starting server bound') !== -1) {
-                        // Assume the server has successfully spawned the moment it says it's listening.
-                        return resolve(process);
-                    }
+                    rateLimit(message);
                 });
 
                 process.stderr.on('data', data => {
@@ -591,8 +618,7 @@ module.exports =
                 'You\'ve likely hit a snag in the Serenata server. Feel free to report it on its bug tracker. ' +
                 'If you do, please include the information printed below.\n \n' +
 
-                'Please do *not* report this to the issue tracker of this package on GitHub as it is not a bug here.' +
-                '\n \n' +
+                'Please do *not* report this to the issue tracker of this package on GitHub as it is not a bug here.\n \n' +
 
                 'The server will attempt to restart itself.\n \n' +
 
@@ -643,14 +669,14 @@ module.exports =
         /**
          * Retrieves a list of available classes in the specified file.
          *
-         * @param {String} uri
+         * @param {String} file
          *
          * @return {Promise}
         */
-        getClassListForFile(uri) {
-            if (!uri) {
+        getClassListForFile(file) {
+            if (!file) {
                 return new CancellablePromise(function(resolve, reject) {
-                    return reject('A uri must be passed');
+                    return reject('No file passed!');
                 });
             }
 
@@ -662,7 +688,7 @@ module.exports =
 
             const parameters = {
                 database : this.getIndexDatabasePath(),
-                uri      : this.phpInvoker.normalizePlatformAndRuntimePath(uri)
+                file     : this.phpInvoker.normalizePlatformAndRuntimePath(file)
             };
 
             return this.performRequest('classList', parameters);
@@ -737,81 +763,24 @@ module.exports =
         /**
          * Resolves a local type in the specified file, based on use statements and the namespace.
          *
-         * @param {String}   uri
-         * @param {Position} position
-         * @param {String}   type
-         * @param {String}   kind The kind of element. Either 'classlike', 'constant' or 'function'.
+         * @param {String}  file
+         * @param {Number}  line The line the type is located at. The first line is 1, not 0.
+         * @param {String}  type
+         * @param {String}  kind The kind of element. Either 'classlike', 'constant' or 'function'.
          *
-         * @return {CancellablePromise}
+         * @return {Promise}
         */
-        resolveType(uri, position, type, kind) {
+        resolveType(file, line, type, kind) {
             if (kind == null) { kind = 'classlike'; }
-            if (!uri) {
+            if (!file) {
                 return new CancellablePromise(function(resolve, reject) {
-                    return reject('A uri must be passed');
+                    return reject('No file passed!');
                 });
             }
 
-            if (!position) {
+            if (!line) {
                 return new CancellablePromise(function(resolve, reject) {
-                    return reject('A position must be passed');
-                });
-            }
-
-            if (!type) {
-                return new CancellablePromise(function(resolve, reject) {
-                    return reject('No type passed');
-                });
-            }
-
-            if (!kind) {
-                return new CancellablePromise(function(resolve, reject) {
-                    return reject('No kind passed');
-                });
-            }
-
-            if ((this.getIndexDatabasePath() == null)) {
-                return new CancellablePromise(function(resolve, reject) {
-                    return reject('Request aborted as there is no project active (yet)');
-                });
-            }
-
-            const parameters = {
-                database : this.getIndexDatabasePath(),
-                type     : type,
-                kind     : kind,
-                uri      : this.phpInvoker.normalizePlatformAndRuntimePath(uri),
-                position : {
-                    line      : position.row,
-                    character : position.column
-                }
-            };
-
-            return this.performRequest('resolveType', parameters);
-        }
-
-        /**
-         * Localizes a type to the specified file, making it relative to local use statements, if possible. If not
-         * possible, null is returned.
-         *
-         * @param {String}   uri
-         * @param {Position} position
-         * @param {String}   type
-         * @param {String}   kind The kind of element. Either 'classlike', 'constant' or 'function'.
-         *
-         * @return {CancellablePromise}
-        */
-        localizeType(uri, position, type, kind) {
-            if (kind == null) { kind = 'classlike'; }
-            if (!uri) {
-                return new CancellablePromise(function(resolve, reject) {
-                    return reject('A uri must be passed');
-                });
-            }
-
-            if (!position) {
-                return new CancellablePromise(function(resolve, reject) {
-                    return reject('A position must be passed');
+                    return reject('No line passed!');
                 });
             }
 
@@ -835,13 +804,64 @@ module.exports =
 
             const parameters = {
                 database : this.getIndexDatabasePath(),
-                type     : type,
-                kind     : kind,
-                uri      : this.phpInvoker.normalizePlatformAndRuntimePath(uri),
-                position : {
-                    line      : position.row,
-                    character : position.column
-                }
+                file     : this.phpInvoker.normalizePlatformAndRuntimePath(file),
+                line,
+                type,
+                kind
+            };
+
+            return this.performRequest('resolveType', parameters);
+        }
+
+        /**
+         * Localizes a type to the specified file, making it relative to local use statements, if possible. If not possible,
+         * null is returned.
+         *
+         * @param {String}  file
+         * @param {Number}  line The line the type is located at. The first line is 1, not 0.
+         * @param {String}  type
+         * @param {String}  kind The kind of element. Either 'classlike', 'constant' or 'function'.
+         *
+         * @return {Promise}
+        */
+        localizeType(file, line, type, kind) {
+            if (kind == null) { kind = 'classlike'; }
+            if (!file) {
+                return new CancellablePromise(function(resolve, reject) {
+                    return reject('No file passed!');
+                });
+            }
+
+            if (!line) {
+                return new CancellablePromise(function(resolve, reject) {
+                    return reject('No line passed!');
+                });
+            }
+
+            if (!type) {
+                return new CancellablePromise(function(resolve, reject) {
+                    return reject('No type passed!');
+                });
+            }
+
+            if (!kind) {
+                return new CancellablePromise(function(resolve, reject) {
+                    return reject('No kind passed!');
+                });
+            }
+
+            if ((this.getIndexDatabasePath() == null)) {
+                return new CancellablePromise(function(resolve, reject) {
+                    return reject('Request aborted as there is no project active (yet)');
+                });
+            }
+
+            const parameters = {
+                database : this.getIndexDatabasePath(),
+                file     : this.phpInvoker.normalizePlatformAndRuntimePath(file),
+                line,
+                type,
+                kind
             };
 
             return this.performRequest('localizeType', parameters);
@@ -850,15 +870,19 @@ module.exports =
         /**
          * Lints the specified file.
          *
-         * @param {String}      uri
-         * @param {String|null} source
+         * @param {String}      file
+         * @param {String|null} source  The source code of the file to index. May be null if a directory is passed instead.
+         * @param {Object}      options Additional options to set. Boolean properties noUnknownClasses, noUnknownMembers,
+         *                              noUnknownGlobalFunctions, noUnknownGlobalConstants, noDocblockCorrectness,
+         *                              noUnusedUseStatements and noMissingDocumentation are supported.
          *
          * @return {CancellablePromise}
         */
-        lint(uri, source) {
-            if (!uri) {
+        lint(file, source, options) {
+            if (options == null) { options = {}; }
+            if (!file) {
                 return new CancellablePromise(function(resolve, reject) {
-                    return reject('A uri must be passed');
+                    return reject('No file passed!');
                 });
             }
 
@@ -870,9 +894,37 @@ module.exports =
 
             const parameters = {
                 database : this.getIndexDatabasePath(),
-                uri      : this.phpInvoker.normalizePlatformAndRuntimePath(uri),
+                file     : this.phpInvoker.normalizePlatformAndRuntimePath(file),
                 stdin    : true
             };
+
+            if (options.noUnknownClasses === true) {
+                parameters['no-unknown-classes'] = true;
+            }
+
+            if (options.noUnknownMembers === true) {
+                parameters['no-unknown-members'] = true;
+            }
+
+            if (options.noUnknownGlobalFunctions === true) {
+                parameters['no-unknown-global-functions'] = true;
+            }
+
+            if (options.noUnknownGlobalConstants === true) {
+                parameters['no-unknown-global-constants'] = true;
+            }
+
+            if (options.noDocblockCorrectness === true) {
+                parameters['no-docblock-correctness'] = true;
+            }
+
+            if (options.noUnusedUseStatements === true) {
+                parameters['no-unused-use-statements'] = true;
+            }
+
+            if (options.noMissingDocumentation === true) {
+                parameters['no-missing-documentation'] = true;
+            }
 
             return this.performRequest('lint', parameters, null, source);
         }
@@ -880,16 +932,16 @@ module.exports =
         /**
          * Fetches all available variables at a specific location.
          *
-         * @param {String}      uri      The URI of the file to examine.
-         * @param {String|null} source   The source code to search. May be null if a file is passed instead.
-         * @param {Position}    position The position into the file to examine.
+         * @param {String}      file   The path to the file to examine. May be null if the source parameter is passed.
+         * @param {String|null} source The source code to search. May be null if a file is passed instead.
+         * @param {Number}      offset The character offset into the file to examine.
          *
          * @return {Promise}
         */
-        getAvailableVariables(uri, source, position) {
-            if (!uri) {
+        getAvailableVariables(file, source, offset) {
+            if (!file) {
                 return new CancellablePromise(function(resolve, reject) {
-                    return reject('A uri must be passed');
+                    return reject('No file passed!');
                 });
             }
 
@@ -900,12 +952,10 @@ module.exports =
             }
 
             const parameters = {
-                database : this.getIndexDatabasePath(),
-                uri      : this.phpInvoker.normalizePlatformAndRuntimePath(uri),
-                position : {
-                    line      : position.row,
-                    character : position.column
-                }
+                database   : this.getIndexDatabasePath(),
+                offset,
+                charoffset : true,
+                file       : this.phpInvoker.normalizePlatformAndRuntimePath(file)
             };
 
             return this.performRequest('availableVariables', parameters, null, source);
@@ -914,16 +964,16 @@ module.exports =
         /**
          * Fetches the contents of the tooltip to display at the specified offset.
          *
-         * @param {String}      uri      The URI of the file to examine.
-         * @param {String|null} source   The source code to search. May be null if a file is passed instead.
-         * @param {Position}    position The position into the file to examine.
+         * @param {String}      file   The path to the file to examine.
+         * @param {String|null} source The source code to search. May be null if a file is passed instead.
+         * @param {Number}      offset The character offset into the file to examine.
          *
          * @return {CancellablePromise}
         */
-        tooltip(uri, source, position) {
-            if (!uri) {
+        tooltip(file, source, offset) {
+            if ((file == null)) {
                 return new CancellablePromise(function(resolve, reject) {
-                    return reject('A uri must be passed');
+                    return reject('Either a path to a file or source code must be passed!');
                 });
             }
 
@@ -934,12 +984,10 @@ module.exports =
             }
 
             const parameters = {
-                database : this.getIndexDatabasePath(),
-                uri      : this.phpInvoker.normalizePlatformAndRuntimePath(uri),
-                position : {
-                    line      : position.row,
-                    character : position.column
-                }
+                database   : this.getIndexDatabasePath(),
+                offset,
+                charoffset : true,
+                file       : this.phpInvoker.normalizePlatformAndRuntimePath(file)
             };
 
             return this.performRequest('tooltip', parameters, null, source);
@@ -948,16 +996,16 @@ module.exports =
         /**
          * Fetches signature help for a method or function call.
          *
-         * @param {String}      uri      The URI of the file to examine.
-         * @param {String|null} source   The source code to search. May be null if a file is passed instead.
-         * @param {Position}    position The position into the file to examine.
+         * @param {String}      file   The path to the file to examine.
+         * @param {String|null} source The source code to search. May be null if a file is passed instead.
+         * @param {Number}      offset The character offset into the file to examine.
          *
          * @return {CancellablePromise}
         */
-        signatureHelp(uri, source, position) {
-            if (!uri) {
+        signatureHelp(file, source, offset) {
+            if ((file == null)) {
                 return new CancellablePromise(function(resolve, reject) {
-                    return reject('A uri must be passed');
+                    return reject('Either a path to a file or source code must be passed!');
                 });
             }
 
@@ -968,31 +1016,28 @@ module.exports =
             }
 
             const parameters = {
-                database : this.getIndexDatabasePath(),
-                uri      : this.phpInvoker.normalizePlatformAndRuntimePath(uri),
-                position : {
-                    line      : position.row,
-                    character : position.column
-                }
+                database   : this.getIndexDatabasePath(),
+                offset,
+                charoffset : true,
+                file       : this.phpInvoker.normalizePlatformAndRuntimePath(file)
             };
 
             return this.performRequest('signatureHelp', parameters, null, source);
         }
 
         /**
-         * Fetches definition information for code navigation purposes of the structural element at the specified
-         * location.
+         * Fetches definition information for code navigation purposes of the structural element at the specified location.
          *
-         * @param {String}      uri      The URI of the file to examine.
-         * @param {String|null} source   The source code to search. May be null if a file is passed instead.
-         * @param {Position}    position The position into the file to examine.
+         * @param {String}      file   The path to the file to examine.
+         * @param {String|null} source The source code to search. May be null if a file is passed instead.
+         * @param {Number}      offset The character offset into the file to examine.
          *
          * @return {CancellablePromise}
         */
-        gotoDefinition(uri, source, position) {
-            if (!uri) {
+        gotoDefinition(file, source, offset) {
+            if ((file == null)) {
                 return new CancellablePromise(function(resolve, reject) {
-                    return reject('A uri must be passed');
+                    return reject('Either a path to a file or source code must be passed!');
                 });
             }
 
@@ -1003,12 +1048,10 @@ module.exports =
             }
 
             const parameters = {
-                database  : this.getIndexDatabasePath(),
-                uri       : this.phpInvoker.normalizePlatformAndRuntimePath(uri),
-                position : {
-                    line      : position.row,
-                    character : position.column
-                }
+                database   : this.getIndexDatabasePath(),
+                offset,
+                charoffset : true,
+                file       : this.phpInvoker.normalizePlatformAndRuntimePath(file)
             };
 
             return this.performRequest('gotoDefinition', parameters, null, source);
@@ -1017,23 +1060,23 @@ module.exports =
         /**
          * Deduces the resulting types of an expression.
          *
-         * @param {String|null} expression        The expression to deduce the type of, e.g. '$this->foo()'. If null,
-         *                                        the expression just before the specified offset will be used.
-         * @param {String}      uri               The URI of the file to examine.
+         * @param {String|null} expression        The expression to deduce the type of, e.g. '$this->foo()'. If null, the
+         *                                        expression just before the specified offset will be used.
+         * @param {String}      file              The path to the file to examine.
          * @param {String|null} source            The source code to search. May be null if a file is passed instead.
-         * @param {Position}    position          The position into the file to examine.
-         * @param {bool}        ignoreLastElement Whether to remove the last element or not, this is useful when the
-         *                                        user is still writing code, e.g. "$this->foo()->b" would normally
-         *                                        return thetype (class) of 'b', as it is the last element, but as the
-         *                                        user is still writing code, you may instead be interested in the type
-         *                                        of 'foo()' instead.
+         * @param {Number}      offset            The character offset into the file to examine.
+         * @param {bool}        ignoreLastElement Whether to remove the last element or not, this is useful when the user
+         *                                        is still writing code, e.g. "$this->foo()->b" would normally return the
+         *                                        type (class) of 'b', as it is the last element, but as the user is still
+         *                                        writing code, you may instead be interested in the type of 'foo()'
+         *                                        instead.
          *
-         * @return {CancellablePromise}
+         * @return {Promise}
         */
-        deduceTypes(expression, uri, source, position, ignoreLastElement) {
-            if (!uri) {
+        deduceTypes(expression, file, source, offset, ignoreLastElement) {
+            if ((file == null)) {
                 return new CancellablePromise(function(resolve, reject) {
-                    return reject('A uri must be passed');
+                    return reject('A path to a file must be passed!');
                 });
             }
 
@@ -1044,14 +1087,14 @@ module.exports =
             }
 
             const parameters = {
-                database : this.getIndexDatabasePath(),
-                uri      : this.phpInvoker.normalizePlatformAndRuntimePath(uri),
-
-                position : {
-                    line      : position.row,
-                    character : position.column
-                }
+                database   : this.getIndexDatabasePath(),
+                offset,
+                charoffset : true
             };
+
+            if (file != null) {
+                parameters.file = this.phpInvoker.normalizePlatformAndRuntimePath(file);
+            }
 
             if (ignoreLastElement) {
                 parameters['ignore-last-element'] = true;
@@ -1067,13 +1110,13 @@ module.exports =
         /**
          * Retrieves autocompletion suggestions for a specific location.
          *
-         * @param {Position}    position The position into the file to examine.
-         * @param {String}      file     The path to the file to examine.
-         * @param {String|null} source   The source code to search. May be null if a file is passed instead.
+         * @param {Number}      offset            The character offset into the file to examine.
+         * @param {String}      file              The path to the file to examine.
+         * @param {String|null} source            The source code to search. May be null if a file is passed instead.
          *
          * @return {CancellablePromise}
         */
-        autocomplete(position, file, source) {
+        autocomplete(offset, file, source) {
             if ((file == null)) {
                 return new CancellablePromise(function(resolve, reject) {
                     return reject('A path to a file must be passed!');
@@ -1087,15 +1130,13 @@ module.exports =
             }
 
             const parameters = {
-                database : this.getIndexDatabasePath(),
-                position : {
-                    line      : position.row,
-                    character : position.column
-                }
+                database   : this.getIndexDatabasePath(),
+                offset,
+                charoffset : true
             };
 
             if (file != null) {
-                parameters.uri = this.phpInvoker.normalizePlatformAndRuntimePath(file);
+                parameters.file = this.phpInvoker.normalizePlatformAndRuntimePath(file);
             }
 
             return this.performRequest('autocomplete', parameters, null, source);
@@ -1104,14 +1145,14 @@ module.exports =
         /**
          * Retrieves a list of document symbols.
          *
-         * @param {String} uri
+         * @param {String} file
          *
          * @return {CancellablePromise}
         */
-        getDocumentSymbols(uri) {
-            if (uri == null) {
+        getDocumentSymbols(file) {
+            if (file == null) {
                 return new CancellablePromise(function(resolve, reject) {
-                    return reject('A uri must be passed');
+                    return reject('A path to a file must be passed!');
                 });
             }
 
@@ -1123,7 +1164,7 @@ module.exports =
 
             const parameters = {
                 database : this.getIndexDatabasePath(),
-                uri      : this.phpInvoker.normalizePlatformAndRuntimePath(uri)
+                file     : this.phpInvoker.normalizePlatformAndRuntimePath(file)
             };
 
             return this.performRequest('documentSymbols', parameters);
@@ -1200,31 +1241,30 @@ module.exports =
         /**
          * Refreshes the specified file or folder. This method is asynchronous and will return immediately.
          *
-         * @param {String|Array}  uri                    The URI of the file or folder to refresh. Alternatively,
-         *                                               this can be a list of items to index at the same time.
-         * @param {String|null}   source                 The source code of the file to index. May be null if a
-         *                                               directory is passed instead.
-         * @param {Callback|null} progressStreamCallback A method to invoke each time progress streaming data is
-         *                                               received.
+         * @param {String|Array}  path                   The full path to the file  or folder to refresh. Alternatively,
+         *                                              this can be a list of items to index at the same time.
+         * @param {String|null}   source                 The source code of the file to index. May be null if a directory is
+         *                                              passed instead.
+         * @param {Callback|null} progressStreamCallback A method to invoke each time progress streaming data is received.
          * @param {Array}         excludedPaths          A list of paths to exclude from indexing.
          * @param {Array}         fileExtensionsToIndex  A list of file extensions (without leading dot) to index.
          *
          * @return {CancellablePromise}
         */
-        reindex(uri, source, progressStreamCallback, excludedPaths, fileExtensionsToIndex) {
-            let urisToIndex;
-            if (typeof uri === 'string') {
-                urisToIndex = [];
+        reindex(path, source, progressStreamCallback, excludedPaths, fileExtensionsToIndex) {
+            let pathsToIndex;
+            if (typeof path === 'string') {
+                pathsToIndex = [];
 
-                if (uri) {
-                    urisToIndex.push(uri);
+                if (path) {
+                    pathsToIndex.push(path);
                 }
 
             } else {
-                urisToIndex = uri;
+                pathsToIndex = path;
             }
 
-            if (uri.length === 0) {
+            if (path.length === 0) {
                 return new CancellablePromise(function(resolve, reject) {
                     return reject('No filename passed!');
                 });
@@ -1246,11 +1286,11 @@ module.exports =
                 progressStreamCallbackWrapper = progressStreamCallback;
             }
 
-            urisToIndex = urisToIndex.map(uri => {
-                return this.phpInvoker.normalizePlatformAndRuntimePath(uri);
+            pathsToIndex = pathsToIndex.map(path => {
+                return this.phpInvoker.normalizePlatformAndRuntimePath(path);
             });
 
-            parameters.uris = urisToIndex;
+            parameters.source = pathsToIndex;
             parameters.exclude = excludedPaths;
             parameters.extension = fileExtensionsToIndex;
 

--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -8,12 +8,9 @@
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
 let Proxy;
-const fs            = require('fs');
 const net           = require('net');
 const path          = require('path');
 const mkdirp        = require('mkdirp');
-const stream        = require('stream');
-const child_process = require('child_process');
 const sanitize      = require('sanitize-filename');
 
 const CancellablePromise = require('./CancellablePromise');
@@ -240,9 +237,8 @@ module.exports =
             if (this.phpServer) {
                 this.phpServerPromise = null;
 
-                return new Promise((resolve, reject) => {
-                    return resolve(this.phpServer);
-                });
+                // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve
+                return Promise.resolve(this.phpServer);
 
             } else if (this.phpServerPromise) {
                 return this.phpServerPromise;
@@ -283,7 +279,10 @@ module.exports =
         rejectAllOpenRequests() {
             for (let id in this.requestQueue) {
                 const request = this.requestQueue[id];
-                request.promise.reject('Socket connection encountered invalid state or was closed, please resend request');
+                request.promise.reject(
+                    'Socket connection encountered invalid ' +
+                    'state or was closed, please resend request'
+                );
             }
 
             return this.requestQueue = {};
@@ -305,7 +304,10 @@ module.exports =
                     });
 
                     this.client.setNoDelay(true);
-                    this.client.on('error', this.onSocketError.bind(this));
+                    this.client.on('error', err => {
+                        this.onSocketError(err);
+                        reject(new Error(err));
+                    });
                     this.client.on('data', this.onDataReceived.bind(this));
                     return this.client.on('close', this.onConnectionClosed.bind(this));
                 });
@@ -330,14 +332,16 @@ module.exports =
          * @param {Object} error
         */
         onSocketError(error) {
-            // Do nothing here, this should silence socket errors such as ECONNRESET. After this is called, the socket will
+            // Do nothing here, this should silence socket errors such as
+            // ECONNRESET. After this is called, the socket will
             // be closed and all handling is performed there.
             return console.warn('The socket connection notified us of an error', error);
         }
 
         /**
          * @param {Boolean} hadError
-        */
+         */
+        // eslint-disable-next-line no-unused-vars
         onConnectionClosed(hadError) {
             return this.closeServerConnection();
         }
@@ -392,7 +396,11 @@ module.exports =
                 const jsonRpcRequest = this.requestQueue[jsonRpcResponse.id];
 
                 if ((jsonRpcRequest == null)) {
-                    console.warn('Received response for request that was already removed from the queue', jsonRpcResponse);
+                    console.warn(
+                        'Received response for request that was ' +
+                        'already removed from the queue',
+                        jsonRpcResponse
+                    );
                     return;
                 }
 
@@ -452,7 +460,11 @@ module.exports =
                     return;
 
                 } else if ((relatedJsonRpcRequest.streamCallback == null)) {
-                    console.warn('Received progress information for a request that isn\'t interested in it', jsonRpcResponse);
+                    console.warn(
+                        'Received progress information for a ' +
+                        'request that isn\'t interested in it',
+                        jsonRpcResponse
+                    );
                     return;
                 }
 
@@ -615,14 +627,14 @@ module.exports =
         showFatalServerError(error) {
             let notification;
             const detail =
-                'You\'ve likely hit a snag in the Serenata server. Feel free to report it on its bug tracker. ' +
-                'If you do, please include the information printed below.\n \n' +
+            'You\'ve likely hit a snag in the Serenata server.' +
+            'Feel free to report it on its bug tracker. ' +
+            'If you do, please include the information printed below.\n \n' +
+            'Please do *not* report this to the issue tracker of this ' +
+            'package on GitHub as it is not a bug here.\n \n' +
+            'The server will attempt to restart itself.\n \n' +
 
-                'Please do *not* report this to the issue tracker of this package on GitHub as it is not a bug here.\n \n' +
-
-                'The server will attempt to restart itself.\n \n' +
-
-                error.data.backtrace;
+            error.data.backtrace;
 
             return notification = atom.notifications.addError('Serenata - Darn, we\'ve crashed!', {
                 dismissable : true,
@@ -814,8 +826,8 @@ module.exports =
         }
 
         /**
-         * Localizes a type to the specified file, making it relative to local use statements, if possible. If not possible,
-         * null is returned.
+         * Localizes a type to the specified file, making it relative to
+         * local use statements, if possible. If not possible, null is returned.
          *
          * @param {String}  file
          * @param {Number}  line The line the type is located at. The first line is 1, not 0.
@@ -871,10 +883,18 @@ module.exports =
          * Lints the specified file.
          *
          * @param {String}      file
-         * @param {String|null} source  The source code of the file to index. May be null if a directory is passed instead.
-         * @param {Object}      options Additional options to set. Boolean properties noUnknownClasses, noUnknownMembers,
-         *                              noUnknownGlobalFunctions, noUnknownGlobalConstants, noDocblockCorrectness,
-         *                              noUnusedUseStatements and noMissingDocumentation are supported.
+         * @param {String|null} source  The source code of the file to index.
+         *                              May be null if a directory is passed
+         *                              instead.
+         *
+         * @param {Object}      options Additional options to set.
+         *                              Boolean properties noUnknownClasses,
+         *                              noUnknownMembers,
+         *                              noUnknownGlobalFunctions,
+         *                              noUnknownGlobalConstants,
+         *                              noDocblockCorrectness,
+         *                              noUnusedUseStatements and
+         *                              noMissingDocumentation are supported.
          *
          * @return {CancellablePromise}
         */
@@ -1026,7 +1046,8 @@ module.exports =
         }
 
         /**
-         * Fetches definition information for code navigation purposes of the structural element at the specified location.
+         * Fetches definition information for code navigation purposes of
+         * the structural element at the specified location.
          *
          * @param {String}      file   The path to the file to examine.
          * @param {String|null} source The source code to search. May be null if a file is passed instead.
@@ -1060,15 +1081,29 @@ module.exports =
         /**
          * Deduces the resulting types of an expression.
          *
-         * @param {String|null} expression        The expression to deduce the type of, e.g. '$this->foo()'. If null, the
-         *                                        expression just before the specified offset will be used.
+         * @param {String|null} expression        The expression to deduce
+         *                                        the type of,
+         *                                        e.g. '$this->foo()'.
+         *                                        If null, the
+         *                                        expression just before the
+         *                                        specified offset will be used.
          * @param {String}      file              The path to the file to examine.
-         * @param {String|null} source            The source code to search. May be null if a file is passed instead.
-         * @param {Number}      offset            The character offset into the file to examine.
-         * @param {bool}        ignoreLastElement Whether to remove the last element or not, this is useful when the user
-         *                                        is still writing code, e.g. "$this->foo()->b" would normally return the
-         *                                        type (class) of 'b', as it is the last element, but as the user is still
-         *                                        writing code, you may instead be interested in the type of 'foo()'
+         * @param {String|null} source            The source code to search.
+         *                                        May be null if a file is
+         *                                        passed instead.
+         * @param {Number}      offset            The character offset into the
+         *                                        file to examine.
+         * @param {bool}        ignoreLastElement Whether to remove the last
+         *                                        element or not, this is useful
+         *                                        when the user
+         *                                        is still writing code, e.g.
+         *                                        "$this->foo()->b" would
+         *                                        normally return the
+         *                                        type (class) of 'b', as it is
+         *                                        the last element, but as the
+         *                                        user is still writing code,
+         *                                        you may instead be interested
+         *                                        in the type of 'foo()'
          *                                        instead.
          *
          * @return {Promise}
@@ -1241,13 +1276,28 @@ module.exports =
         /**
          * Refreshes the specified file or folder. This method is asynchronous and will return immediately.
          *
-         * @param {String|Array}  path                   The full path to the file  or folder to refresh. Alternatively,
-         *                                              this can be a list of items to index at the same time.
-         * @param {String|null}   source                 The source code of the file to index. May be null if a directory is
-         *                                              passed instead.
-         * @param {Callback|null} progressStreamCallback A method to invoke each time progress streaming data is received.
-         * @param {Array}         excludedPaths          A list of paths to exclude from indexing.
-         * @param {Array}         fileExtensionsToIndex  A list of file extensions (without leading dot) to index.
+         * @param {String|Array}  path                   The full path to the
+         *                                               file  or folder to
+         *                                               refresh. Alternatively,
+         *                                               this can be a list of
+         *                                               items to index at the
+         *                                               same time.
+         *
+         * @param {String|null}   source                 The source code of the
+         *                                               file to index. May be
+         *                                               null if a directory is
+         *                                               passed instead.
+         *
+         * @param {Callback|null} progressStreamCallback A method to invoke each
+         *                                               time progress streaming
+         *                                               data is received.
+         * @param {Array}         excludedPaths          A list of paths to
+         *                                               exclude from indexing.
+         *
+         * @param {Array}         fileExtensionsToIndex  A list of file
+         *                                               extensions
+         *                                               (without leading dot)
+         *                                               to index.
          *
          * @return {CancellablePromise}
         */


### PR DESCRIPTION
I get:

The PHP Server has something to say:
Warning: pcntl_signal_dispatch() has been disabled for security reasons in /home/fram/.cache/php-ide-serenata/server/files/vendor/react/event-loop/src/StreamSelectLoop.php on line 232

Approximately every 5 seconds which is pretty annoying.
Perhaps a better fix would be for the server to stop reporting this?
I'm open to suggestions, I like this package and would like to make
it more polished.