### PR TITLE
fix windows config setup

### DIFF
--- a/lib/ProjectManager.js
+++ b/lib/ProjectManager.js
@@ -60,9 +60,9 @@ class ProjectManager
         const template =
 `{
     "uris": [
-        "file://${mainFolder}"
+        "file://${mainFolder.replace(/\\/g, '\\\\')}"
     ],
-    "indexDatabaseUri": "${indexDatabaseUri}",
+    "indexDatabaseUri": "${indexDatabaseUri.replace(/\\/g, '\\\\')}",
     "phpVersion": 7.3,
     "excludedPathExpressions": [],
     "fileExtensions": [


### PR DESCRIPTION
When initially setting up the new config file in windows we need to escape any backslashes in the folder path

before:
```js
{
    "uris": [
        "file://C:\folder"
    ],
    "indexDatabaseUri": "file://C:\Users\user\AppData\Roaming\php-ide-serenata\index-5c51a4ab6ab1bda8bf0d2e20c0bdc99f.sqlite",
    "phpVersion": 7.3,
    "excludedPathExpressions": [],
    "fileExtensions": [
        "php"
    ]
}
```

after:
```js
{
    "uris": [
        "file://C:\\folder"
    ],
    "indexDatabaseUri": "file://C:\\Users\\user\\AppData\\Roaming\\php-ide-serenata\\index-5c51a4ab6ab1bda8bf0d2e20c0bdc99f.sqlite",
    "phpVersion": 7.3,
    "excludedPathExpressions": [],
    "fileExtensions": [
        "php"
    ]
}
```