### PR TITLE
Add busy-signal package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
   },
   "package-deps": [
     "atom-ide-ui",
-    "intentions"
+    "intentions",
+    "busy-signal"
   ],
   "keywords": [
     "serenata",


### PR DESCRIPTION
I was having the same issue as https://github.com/Gert-dev/php-ide-serenata/issues/490 with no packages installed other than those in Core, and the two dependencies listed for this package.

I experienced the issue through the "Test my setup" button on the post-installation pop-up that directs the user to install the Serenata server. After installing the busy-signal package and retrying the config test, the error went away.

I added the busy-signal package as a dependency, and then installed my fork of the php-ide-serenata package.

I was able to verify that the busy-signal package was installed along side the other package dependencies, and that the configuration test ran successfully with this change.