### PR TITLE
Filter file indexing commands based on project configs

### DIFF
--- a/lib/SerenataClient.js
+++ b/lib/SerenataClient.js
@@ -375,8 +375,65 @@ class SerenataClient extends AutoLanguageClient
     }
 
     filterChangeWatchedFiles(filePath) {
-        // Prevent changes to the index file from spamming change events.
-        return !filePath.includes('/.serenata/');
+        if (this.filterChangeWatchedFilesByProjectUris(filePath)) {
+            return false;
+        }
+
+        if (this.filterChangeWatchedFilesByProjectExcludes(filePath)) {
+            return false;
+        }
+
+        if (this.filterChangeWatchedFilesByProjectExtensions(filePath)) {
+            return false;
+        }
+
+        const hardcodedIgnores = [
+            '/.serenata/',
+            '/.git/',
+        ];
+
+        for (const value of hardcodedIgnores) {
+            if (filePath.includes(value)) {
+                return false;
+            }
+        }
+    }
+
+    filterChangeWatchedFilesByProjectUris(filePath) {
+        const projectConfig = this.container.getProjectManager().getCurrentProjectSettings();
+        const uris = projectConfig.uris || [];
+
+        return uris.some((fileUriPath) => {
+            `file://${filePath}`.includes(`${fileUriPath}/`);
+        });
+    }
+
+    filterChangeWatchedFilesByProjectExcludes(filePath) {
+        const projectConfig = this.container.getProjectManager().getCurrentProjectSettings();
+        const expressions = projectConfig.excludedPathExpressions || [];
+
+        return expressions.some((pathExpression) => {
+            /**
+             * FIXME: Serenata server tries to parse expressions as regexes and
+             * only considers them as strings if parsing fails. But here we only
+             * consider them as plain strings.
+             */
+            filePath.includes(pathExpression);
+        });
+    }
+
+    filterChangeWatchedFilesByProjectExtensions(filePath) {
+        const projectConfig = this.container.getProjectManager().getCurrentProjectSettings();
+        const extensions = projectConfig.fileExtensions || [];
+
+        return extensions.some((extension) => {
+            /**
+             * FIXME: Serenata server tries to parse expressions as regexes and
+             * only considers them as strings if parsing fails. But here we only
+             * consider them as plain strings.
+             */
+            filePath.slice(-1 * extension.length) === extension;
+        });
     }
 
     onDidConvertAutocomplete(completionItem, suggestion/*, request*/) {

--- a/lib/SerenataClient.js
+++ b/lib/SerenataClient.js
@@ -375,6 +375,10 @@ class SerenataClient extends AutoLanguageClient
     }
 
     filterChangeWatchedFiles(filePath) {
+        if (!this.container.getProjectManager().getCurrentProjectSettings()) {
+            return false;
+        }
+
         if (!this.filterAcceptsByProjectUris(filePath)) {
             return false;
         }

--- a/lib/SerenataClient.js
+++ b/lib/SerenataClient.js
@@ -375,15 +375,15 @@ class SerenataClient extends AutoLanguageClient
     }
 
     filterChangeWatchedFiles(filePath) {
-        if (this.filterChangeWatchedFilesByProjectUris(filePath)) {
+        if (!this.filterAcceptsByProjectUris(filePath)) {
             return false;
         }
 
-        if (this.filterChangeWatchedFilesByProjectExcludes(filePath)) {
+        if (!this.filterAcceptsByProjectExcludes(filePath)) {
             return false;
         }
 
-        if (this.filterChangeWatchedFilesByProjectExtensions(filePath)) {
+        if (!this.filterAcceptsByProjectExtensions(filePath)) {
             return false;
         }
 
@@ -399,40 +399,35 @@ class SerenataClient extends AutoLanguageClient
         }
     }
 
-    filterChangeWatchedFilesByProjectUris(filePath) {
+    filterAcceptsByProjectUris(filePath) {
         const projectConfig = this.container.getProjectManager().getCurrentProjectSettings();
         const uris = projectConfig.uris || [];
 
-        return uris.some((fileUriPath) => {
-            `file://${filePath}`.includes(`${fileUriPath}/`);
+        return uris.some((dirUri) => {
+            `file://${filePath}`.includes(`${dirUri}/`);
         });
     }
 
-    filterChangeWatchedFilesByProjectExcludes(filePath) {
+    filterAcceptsByProjectExcludes(filePath) {
         const projectConfig = this.container.getProjectManager().getCurrentProjectSettings();
         const expressions = projectConfig.excludedPathExpressions || [];
 
-        return expressions.some((pathExpression) => {
+        return expressions.every((pathExpression) => {
             /**
              * FIXME: Serenata server tries to parse expressions as regexes and
              * only considers them as strings if parsing fails. But here we only
              * consider them as plain strings.
              */
-            filePath.includes(pathExpression);
+            !filePath.includes(pathExpression);
         });
     }
 
-    filterChangeWatchedFilesByProjectExtensions(filePath) {
+    filterAcceptsByProjectExtensions(filePath) {
         const projectConfig = this.container.getProjectManager().getCurrentProjectSettings();
         const extensions = projectConfig.fileExtensions || [];
 
         return extensions.some((extension) => {
-            /**
-             * FIXME: Serenata server tries to parse expressions as regexes and
-             * only considers them as strings if parsing fails. But here we only
-             * consider them as plain strings.
-             */
-            filePath.slice(-1 * extension.length) === extension;
+            filePath.slice(-1 * extension.length - 1) === `.${extension}`;
         });
     }
 


### PR DESCRIPTION
This patch adds filtering of file index requests based on project configuration prior to dispatching them to the Serenata language server app. 

Currently the Atom plugin is sending nonsensical indexing requests to the backend every time e.g. a Symfony PHP app writes to a local log file or flushes caches. This will often lead to completely unnecessary project reindexing and often enough even seemingly endless loops that consume 100 % of CPU time "forever" and forces one to restart the whole Atom editor.

Also in general it is much better for performance to avoid pointless TCP traffic as the Serenata server app seems to be quite heavy considering laptop use, where battery life and heat dissipation are of significant concern.