### PR TITLE
Revert prefix override workaround

### DIFF
--- a/lib/SerenataClient.js
+++ b/lib/SerenataClient.js
@@ -365,15 +365,6 @@ class SerenataClient extends AutoLanguageClient
         return provider;
     }
 
-    getSuggestions(request) {
-        // Temporary workaround for the languageclient library applying its own filtering and resorting on top of the
-        // result list returned by the server, which should be the sole source of truth and not be modified in any
-        // further way. See also https://github.com/atom/atom-languageclient/issues/218.
-        request.prefix = '';
-
-        return super.getSuggestions(request);
-    }
-
     filterChangeWatchedFiles(filePath) {
         // Prevent changes to the index file from spamming change events.
         return !filePath.includes('/.serenata/');


### PR DESCRIPTION
It seems the upstream bug in [atom-languageclient](https://github.com/atom-community/atom-languageclient/issues) no longer exists (after the transition from atom into atom-ide-community), so the workaround for filtering and sorting is no longer needed. As I tested, the extension works perfectly with this change (i.e. without the workaround).

Closes #501 and #485. Should close #489 as well.